### PR TITLE
feat: add ssr to fetch dailies on the server

### DIFF
--- a/src/components/MyTeam/MyTeam.gql.ts
+++ b/src/components/MyTeam/MyTeam.gql.ts
@@ -1,7 +1,7 @@
 import { graphql } from 'react-relay';
 
 export const myTeamQuery = graphql`
-  query MyTeamQuery($first: Int = 5, $after: String = null) {
+  query MyTeamQuery($first: Int = 10, $after: String = null) {
     me {
       team {
         ...DailiesFragment

--- a/src/components/MyTeam/index.tsx
+++ b/src/components/MyTeam/index.tsx
@@ -9,7 +9,13 @@ import { myTeamQuery } from './MyTeam.gql';
 import Dailies from './Dailies';
 
 const MyTeam = () => {
-  const data = useLazyLoadQuery<MyTeamQuery>(myTeamQuery, { first: 10 });
+  const data = useLazyLoadQuery<MyTeamQuery>(
+    myTeamQuery,
+    {},
+    {
+      fetchPolicy: 'store-or-network',
+    },
+  );
 
   return (
     <Grid container spacing={1} direction='column' sx={{ mx: 'auto', maxWidth: 600 }}>


### PR DESCRIPTION
# Description

- Config fetchQuery to execute during server side props. 
How it works
- Nextjs execute the fetchQuery on the server
- The return from the server is the data that is hydrated to the relay store
- The component that renders the daily list attempts to load dailies but first it will check if the daily connection is already present in the relay store.
- Since the date is already in the store, the client does not make any aditional request.
- Since the server returned the html with all dailies loaded with have instant display of the items on the screen. SSR is really nice!

![image](https://user-images.githubusercontent.com/10724115/196584643-f253e8ea-5aa9-4472-8853-810bfd7c568b.png)


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes